### PR TITLE
chore!: upgrade immer to v10.1

### DIFF
--- a/packages/immer-yjs/package.json
+++ b/packages/immer-yjs/package.json
@@ -28,11 +28,11 @@
         "release": "standard-version"
     },
     "peerDependencies": {
-        "immer": "^9.0.12",
+        "immer": "^10.1.1",
         "yjs": "^13.5.35"
     },
     "devDependencies": {
-        "immer": "^9.0.12",
+        "immer": "^10.1.1",
         "standard-version": "^9.3.2",
         "typescript": "^4.6.3",
         "vite": "^2.9.6",

--- a/packages/immer-yjs/src/immer-yjs.ts
+++ b/packages/immer-yjs/src/immer-yjs.ts
@@ -1,4 +1,4 @@
-import produce, { enablePatches, Patch, produceWithPatches } from 'immer'
+import { enablePatches, Patch, produce, produceWithPatches } from 'immer'
 import * as Y from 'yjs'
 
 import { JSONArray, JSONObject, JSONValue } from './types'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2396,7 +2396,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "immer-yjs@workspace:packages/immer-yjs"
   dependencies:
-    immer: "npm:^9.0.12"
+    immer: "npm:^10.1.1"
     standard-version: "npm:^9.3.2"
     typescript: "npm:^4.6.3"
     vite: "npm:^2.9.6"
@@ -2404,15 +2404,15 @@ __metadata:
     vitest: "npm:^0.10.0"
     yjs: "npm:^13.5.35"
   peerDependencies:
-    immer: ^9.0.12
+    immer: ^10.1.1
     yjs: ^13.5.35
   languageName: unknown
   linkType: soft
 
-"immer@npm:^9.0.12":
-  version: 9.0.12
-  resolution: "immer@npm:9.0.12"
-  checksum: 1eff01ff8286cdbe6cef16cee27a477b99bf34d1a2f55edb4080f7cce9b524d68f3001b9cb205ea21dbf6a874051a9d53dd1e73854c9cb3ec05cdc83a77d3609
+"immer@npm:^10.1.1":
+  version: 10.1.1
+  resolution: "immer@npm:10.1.1"
+  checksum: 9dacf1e8c201d69191ccd88dc5d733bafe166cd45a5a360c5d7c88f1de0dff974a94114d72b35f3106adfe587fcfb131c545856184a2247d89d735ad25589863
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Upgrade immer to version 10.1.

According to the migration steps, the only thing we need to do is to replace the default import:

> Replace all default imports: Replace import produce from "immer" with import {produce} from "immer".

I am marking this as a breaking change, because immer v10 has breaking changes.